### PR TITLE
Imported the fuse library at the correct version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/bazil.org/fuse"]
+	path = vendor/bazil.org/fuse
+	url = https://github.com/bazil/fuse


### PR DESCRIPTION
SubFS requires a specific version of the Fuse package. This vendoring addition helps include the correct version.